### PR TITLE
Add Google Meet add-on scaffold

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,0 +1,29 @@
+async function initAddon() {
+  try {
+    const session = await google.meet.addons.createAddonSession();
+
+    const metadataEl = document.getElementById('metadata');
+    const meeting = session.meeting || session.meetingSpace || {};
+    metadataEl.textContent = 'Meeting metadata:\n' + JSON.stringify(meeting, null, 2);
+
+    const userInfoEl = document.getElementById('userinfo');
+    const user = session.currentUser || session.currentParticipant || {};
+    if (user.displayName) {
+      userInfoEl.textContent = `Signed in as ${user.displayName}`;
+    } else if (user.person && user.person.displayName) {
+      userInfoEl.textContent = `Signed in as ${user.person.displayName}`;
+    } else {
+      userInfoEl.textContent = 'User information unavailable';
+    }
+  } catch (err) {
+    console.error('Failed to initialize add-on', err);
+    const metadataEl = document.getElementById('metadata');
+    if (metadataEl) {
+      metadataEl.textContent = 'Failed to initialize add-on.';
+    }
+  }
+}
+
+google.meet.addons.onLoad(() => {
+  initAddon();
+});

--- a/mainstage.html
+++ b/mainstage.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Meet Activity Detector - Main Stage</title>
+</head>
+<body>
+  <h1>Main Stage</h1>
+  <pre id="metadata">Loading meeting data...</pre>
+  <div id="userinfo"></div>
+  <script src="https://meet.google.com/addons/sdk.js"></script>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,18 @@
+{
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/userinfo.profile"
+  ],
+  "addOns": {
+    "common": {
+      "name": "Meet Activity Detector"
+    },
+    "meet": {
+      "addOnUrlPatterns": [
+        "https://<username>.github.io/Meet-Activity-Detector/*"
+      ],
+      "addOnOrigins": [
+        "https://<username>.github.io"
+      ]
+    }
+  }
+}

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Meet Activity Detector - Side Panel</title>
+</head>
+<body>
+  <h1>Welcome to Meet Activity Detector</h1>
+  <pre id="metadata">Loading meeting data...</pre>
+  <div id="userinfo"></div>
+  <script src="https://meet.google.com/addons/sdk.js"></script>
+  <script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add side panel and main stage HTML pages that load the Google Meet SDK
- Include `main.js` with add-on initialization and user/meeting display logic
- Provide manifest for Marketplace deployment without local logo references

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d4cf246c0832dadb6b6074a1b2fe0